### PR TITLE
[FIX] Revert NowPlayingBar image to <img>

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # theppitak.me
 
-![Theppitak M_](https://github.com/mmmmmob/me.theppitak/assets/141404845/29d12b14-2540-4953-9c58-075005d9442d)
+![Theppitak M_](https://github.com/user-attachments/assets/a68fa078-4a0d-46fc-a42e-7e070b92083b)
 
 theppitak.me , my portfolio site with markdown blogs built with React, NPM, and Next.js. Design with cleanliness and simplicity in mind.
 
@@ -83,7 +83,7 @@ The blog system supports rendering Markdown files with front matter metadata. Th
 To create a new blog post:
 
 1. **Create a Markdown file**  
-   Save your post in the `src/content/blogs/` directory (or your designated content folder) with a `.md` extension, e.g. `my-first-post.md`.
+   Save your post in the `src/posts/` directory with a `.md` extension, e.g. `my-first-post.md`.
 
 2. **Add front matter to the top of the file**  
    Use the following structure to define metadata for the post:
@@ -94,8 +94,8 @@ To create a new blog post:
    date: "2025-05-25"
    slug: "test-post"
    excerpt: "A brief description of what this post is about."
-   image: "/path/to/image.jpg"
-   draft: false
+   image: "/path/to/image.jpg" //optional
+   draft: false //optional
    ---
    ```
 
@@ -109,7 +109,7 @@ To create a new blog post:
    npm run dev
    ```
 
-Then navigate to the Blogs section to see your post. Posts marked with `draft:` true will not be shown in production.
+Then navigate to the Blogs section to see your post. Posts marked with `draft: true` will not be shown in production.
 
 ## Technologies Used
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theppitak.me",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -39,9 +39,9 @@ export const NowPlaying = () => {
           ) : (
             <div className="flex self-center">
               <BiSolidBarChartAlt2 size={18} className="mx-1" />
-              <Image
-                src={result?.albumImageUrl ?? "/default-album-art.png"}
-                alt={`${result?.title ?? "Unknown"} album art`}
+              <img
+                src={result?.albumImageUrl}
+                alt={`${result?.title} album art`}
                 width={20}
                 height={20}
                 className="mx-1 size-5 self-end rounded-md"

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useNowPlaying } from "@/hooks/useNowPlaying";
-import Image from "next/image";
 import { BiSolidBarChartAlt2 } from "react-icons/bi";
 
 export const NowPlaying = () => {

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -39,8 +39,8 @@ export const NowPlaying = () => {
             <div className="flex self-center">
               <BiSolidBarChartAlt2 size={18} className="mx-1" />
               <img
-                src={result?.albumImageUrl}
-                alt={`${result?.title} album art`}
+                src={result?.albumImageUrl ?? "/default-album-art.png"}
+                alt={`${result?.title ?? "Unknown"} album art`}
                 width={20}
                 height={20}
                 className="mx-1 size-5 self-end rounded-md"

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -39,7 +39,7 @@ export const NowPlaying = () => {
             <div className="flex self-center">
               <BiSolidBarChartAlt2 size={18} className="mx-1" />
               <img
-                src={result?.albumImageUrl ?? "/default-album-art.png"}
+                src={result?.albumImageUrl ?? "https://placecats.com/20/20"}
                 alt={`${result?.title ?? "Unknown"} album art`}
                 width={20}
                 height={20}

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -9,6 +9,7 @@ const Title = () => {
           alt="avatar"
           width={128}
           height={128}
+          sizes="(max-width: 639px) 128px, 80px"
           className="mr-3 size-20 self-center rounded-md max-sm:size-32"
         />
         <div className="self-center text-start">


### PR DESCRIPTION
NowPlayingBar occasionally fetch song data via Spotify API. <Image> cannot use with SSR page.